### PR TITLE
Add bin/overdrive_reaper script for manually kicking off the Celery reaper tasks

### DIFF
--- a/bin/overdrive_reaper
+++ b/bin/overdrive_reaper
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""
+Manually kicks off the Overdrive reaper Celery task.
+
+Use --collection-name to reap a single collection, or --reap-all to fan out
+over every Overdrive collection.
+"""
+from palace.manager.scripts.overdrive import OverdriveReaperScript
+
+OverdriveReaperScript().run()

--- a/src/palace/manager/scripts/overdrive.py
+++ b/src/palace/manager/scripts/overdrive.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from palace.util.exceptions import PalaceValueError
+
+from palace.manager.celery.tasks.overdrive import reap_all_collections, reap_collection
+from palace.manager.scripts.base import Script
+from palace.manager.sqlalchemy.model.collection import Collection
+
+
+class OverdriveReaperScript(Script):
+    """A convenient script for manually kicking off the overdrive reaper Celery tasks."""
+
+    @classmethod
+    def arg_parser(cls, _db: Session) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser(
+            description="Manually kick off the Overdrive reaper Celery task."
+        )
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            "--collection-name",
+            help="Name of the Overdrive collection to reap.",
+        )
+        group.add_argument(
+            "--reap-all",
+            action="store_true",
+            help="Reap all Overdrive collections.",
+        )
+        return parser
+
+    def do_run(self, *args: Any, **kwargs: Any) -> None:
+        parsed = self.parse_command_line(self._db, *args, **kwargs)
+        if parsed.collection_name:
+            collection = Collection.by_name(self._db, parsed.collection_name)
+            if collection is None:
+                raise PalaceValueError(
+                    f"No collection found with name '{parsed.collection_name}'."
+                )
+            reap_collection.delay(collection.id)
+            self.log.info(
+                f'The "reap_collection" task has been queued for collection '
+                f"'{parsed.collection_name}'. See the celery logs for details."
+            )
+        else:
+            reap_all_collections.delay()
+            self.log.info(
+                'The "reap_all_collections" task has been queued for execution. '
+                "See the celery logs for details about task execution."
+            )

--- a/tests/manager/scripts/test_overdrive.py
+++ b/tests/manager/scripts/test_overdrive.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from palace.util.exceptions import PalaceValueError
+from palace.util.log import LogLevel
+
+from palace.manager.scripts.overdrive import OverdriveReaperScript
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.services import ServicesFixture
+
+
+class TestOverdriveReaperScript:
+
+    def test_reap_all(
+        self,
+        db: DatabaseTransactionFixture,
+        services_fixture: ServicesFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(LogLevel.info)
+        with patch("palace.manager.scripts.overdrive.reap_all_collections") as mock:
+            OverdriveReaperScript(db.session, services_fixture.services).do_run(
+                ["--reap-all"]
+            )
+            mock.delay.assert_called_once_with()
+            assert '"reap_all_collections" task has been queued' in caplog.text
+
+    def test_reap_collection(
+        self,
+        db: DatabaseTransactionFixture,
+        services_fixture: ServicesFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(LogLevel.info)
+        collection = db.collection()
+        with patch("palace.manager.scripts.overdrive.reap_collection") as mock:
+            OverdriveReaperScript(db.session, services_fixture.services).do_run(
+                ["--collection-name", collection.name]
+            )
+            mock.delay.assert_called_once_with(collection.id)
+            assert '"reap_collection" task has been queued' in caplog.text
+
+    def test_reap_collection_not_found(
+        self,
+        db: DatabaseTransactionFixture,
+        services_fixture: ServicesFixture,
+    ) -> None:
+        with pytest.raises(PalaceValueError, match="No collection found"):
+            OverdriveReaperScript(db.session, services_fixture.services).do_run(
+                ["--collection-name", "does-not-exist"]
+            )
+
+    def test_no_args_exits(
+        self,
+        db: DatabaseTransactionFixture,
+        services_fixture: ServicesFixture,
+    ) -> None:
+        with pytest.raises(SystemExit):
+            OverdriveReaperScript(db.session, services_fixture.services).do_run([])


### PR DESCRIPTION
## Description

Re-introduces `bin/overdrive_reaper` as a CLI wrapper for the Celery-based overdrive reaper tasks added in #3305. The script enqueues either `reap_all_collections` (fan-out over all Overdrive collections) or `reap_collection` (a single named collection), depending on which flag is passed.

The script lives in `src/palace/manager/scripts/overdrive.py` (`OverdriveReaperScript`) and follows the same pattern as `bin/update_saml_metadata`.

**Usage:**
```
bin/overdrive_reaper --reap-all
bin/overdrive_reaper --collection-name "My Overdrive Collection"
```

Exactly one of `--reap-all` or `--collection-name` must be provided. Requiring an explicit flag is intentional: fanning out over all collections is expensive, so operators must opt-in rather than trigger it accidentally with no arguments.

## Motivation and Context

#3305 converted the synchronous `bin/overdrive_reaper` cron script to a pair of Celery tasks scheduled hourly via Beat, and deleted the old bin script. This leaves no way to manually trigger a reap outside of the normal schedule — useful when:

- A transient API failure left a collection partially reaped and an operator wants to re-run immediately.
- An operator wants to verify reaper behaviour against a specific collection without waiting for the next Beat tick.
- A targeted reap of one collection is needed after a known catalog change.

## How Has This Been Tested?

- `mypy` passes on both new files.
- Unit tests in `tests/manager/scripts/test_overdrive.py` (`TestOverdriveReaperScript`) cover:
  - `--reap-all` queues `reap_all_collections.delay()` once.
  - `--collection-name` looks up the collection and queues `reap_collection.delay(collection.id)`.
  - `--collection-name` with a non-existent name raises `PalaceValueError`.
  - No arguments causes `SystemExit` (argparse required-group enforcement).
- All pre-commit hooks passed.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.