### PR TITLE
Fix works with stale Adult audience after FBJUV BISAC reclassification

### DIFF
--- a/alembic/versions/20260512_d856ff4dbefb_reset_audience_for_works_with_mis_.py
+++ b/alembic/versions/20260512_d856ff4dbefb_reset_audience_for_works_with_mis_.py
@@ -1,0 +1,61 @@
+"""Reset audience for works with mis-classified FB BISAC subjects
+
+Works linked to BISAC subjects whose identifier begins with "FB" (e.g. FBJUV*, FBYA*)
+were incorrectly assigned audience="Adult" before the scrubber fix landed. The
+classify_unchecked_subjects repair task reclassified the subjects correctly, but a
+structural side-effect in that task meant some works were never re-presented. This
+migration resets work.audience to NULL for those works so the startup task can
+re-run calculate_presentation() on them.
+
+Revision ID: d856ff4dbefb
+Revises: 05a95c828149
+Create Date: 2026-05-12 22:11:05.399881+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from palace.manager.util.migration.helpers import migration_logger
+
+# revision identifiers, used by Alembic.
+revision = "d856ff4dbefb"
+down_revision = "05a95c828149"
+branch_labels = None
+depends_on = None
+
+log = migration_logger(revision)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    result = conn.execute(
+        sa.text(
+            """
+            UPDATE works
+            SET audience = NULL
+            WHERE audience = 'Adult'
+              AND id IN (
+                  SELECT DISTINCT lp.work_id
+                  FROM licensepools lp
+                  JOIN identifiers i ON i.id = lp.identifier_id
+                  JOIN classifications c ON c.identifier_id = i.id
+                  JOIN subjects s ON s.id = c.subject_id
+                  WHERE s.type = 'BISAC'
+                    AND s.identifier LIKE 'FB%'
+                    AND s.audience IN ('Children', 'Young Adult')
+              )
+            RETURNING id
+            """
+        )
+    )
+    rows = list(result)
+    log.info(
+        f"Reset audience=NULL for {len(rows)} works with mis-classified FB BISAC subjects"
+    )
+
+
+def downgrade() -> None:
+    # Cannot reliably restore the original audience values; intentionally a no-op.
+    pass

--- a/src/palace/manager/celery/tasks/work.py
+++ b/src/palace/manager/celery/tasks/work.py
@@ -16,6 +16,29 @@ from palace.manager.sqlalchemy.model.work import Work
 
 
 @shared_task(queue=QueueNames.default, bind=True)
+def reclassify_null_audience_works(task: Task) -> None:
+    """Reclassify all works whose audience was reset to NULL by a repair migration.
+
+    Iterates works with audience IS NULL in ascending id order and calls
+    calculate_presentation() on each, committing after every work so that
+    progress is preserved if the task is interrupted.
+    """
+    with task.session() as session:
+        policy = PresentationCalculationPolicy.recalculate_classification()
+        last_id: int | None = None
+        while True:
+            qu = session.query(Work).filter(Work.audience.is_(None)).order_by(Work.id)
+            if last_id is not None:
+                qu = qu.filter(Work.id > last_id)
+            work = qu.first()
+            if not work:
+                break
+            last_id = work.id
+            work.calculate_presentation(policy=policy)
+            session.commit()
+
+
+@shared_task(queue=QueueNames.default, bind=True)
 def classify_unchecked_subjects(task: Task) -> None:
     """Reclassify all Works whose current classifications appear to
     depend on Subjects in the 'unchecked' state.

--- a/startup_tasks/2026_05_12_reclassify_fb_misclassified_works.py
+++ b/startup_tasks/2026_05_12_reclassify_fb_misclassified_works.py
@@ -1,0 +1,20 @@
+"""Reclassify works whose audience was reset by the FB BISAC mis-classification repair.
+
+The migration d856ff4dbefb set audience=NULL for works that had audience='Adult' but
+were linked to FB-prefixed BISAC subjects now correctly classified as Children/Young
+Adult. This task dispatches the one-time Celery job that re-runs calculate_presentation()
+on those works."""
+
+from __future__ import annotations
+
+import logging
+
+from celery.canvas import Signature
+from sqlalchemy.orm import Session
+
+from palace.manager.celery.tasks.work import reclassify_null_audience_works
+from palace.manager.service.container import Services
+
+
+def run(services: Services, session: Session, log: logging.Logger) -> Signature | None:
+    return reclassify_null_audience_works.s()

--- a/tests/manager/celery/tasks/test_work.py
+++ b/tests/manager/celery/tasks/test_work.py
@@ -88,3 +88,33 @@ def test_subject_checked(
     with patch.object(Work, "calculate_presentation") as calc_pres:
         work_tasks.classify_unchecked_subjects.delay().wait()
     assert calc_pres.call_count == 0
+
+
+def test_reclassify_null_audience_works(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+):
+    """reclassify_null_audience_works calls calculate_presentation for works with NULL audience
+    and leaves works with a non-NULL audience untouched."""
+    null_works = []
+    for _ in range(3):
+        work: Work = db.work(with_license_pool=True)
+        work.audience = None
+        null_works.append(work)
+
+    adult_work: Work = db.work(with_license_pool=True)
+    # audience defaults to "Adult" in db.work()
+
+    db.session.commit()
+
+    with patch.object(Work, "calculate_presentation") as calc_pres:
+        work_tasks.reclassify_null_audience_works.delay().wait()
+
+    # Only the three null-audience works should trigger calculate_presentation.
+    assert calc_pres.call_count == 3
+
+    # Verify the recalculate_classification policy is used for each call.
+    for call_obj in calc_pres.call_args_list:
+        policy = call_obj[1]["policy"]
+        assert policy.classify is True
+        assert policy.choose_edition is False


### PR DESCRIPTION
## Description

Works from Palace Marketplace with FBJUV* BISAC subjects were incorrectly assigned `audience='Adult'` before the scrubber fix landed. Previous migrations reset `subjects.checked=False` and `classify_unchecked_subjects` re-ran, correctly updating the subject records to `audience='Children'`. However, some `works.audience` values remained stale as `'Adult'`.

### Root cause

`classify_unchecked_subjects` iterates unchecked subjects one at a time. When Work A is processed, `calculate_presentation()` calls `assign_to_genre()` on **all** unchecked subjects in Work A's classification set — including subjects shared with Work B. After `session.commit()` those subjects have `checked=True`. When the outer generator advances to the next subject, it is already `checked=True`, so Work B is never discovered and `work.calculate_presentation()` is never called for it. Work B's `work.audience` stays stale.

## Motivation and Context

Books that are clearly children's titles (e.g. `typicalAgeRange=3-12`, FBJUV classifications) were surfacing as Adult audience in the Palace catalog due to this stale value.

## Changes

- **Migration `d856ff4dbefb`** — resets `work.audience = NULL` for all works that have `audience='Adult'` and are linked (via license pool -> identifier -> classification) to a BISAC subject with `identifier LIKE 'FB%'` whose `audience` is now `'Children'` or `'Young Adult'`. Using `FB%` (rather than just `FBJUV%`) captures any other Palace Marketplace prefixed codes (e.g. `FBYA*`) that fell through to the adult catch-all.

- **New Celery task `reclassify_null_audience_works`** (`src/palace/manager/celery/tasks/work.py`) — iterates all works with `audience IS NULL` in ascending `id` order, calling `calculate_presentation(policy=recalculate_classification())` on each and committing after every work to preserve progress if interrupted.

- **Startup task `2026_05_12_reclassify_fb_misclassified_works.py`** — one-time startup task that dispatches `reclassify_null_audience_works` at the next deploy. Tracked in the `startup_tasks` table so it runs exactly once.

## How Has This Been Tested?

- Added `test_reclassify_null_audience_works` to `tests/manager/celery/tasks/test_work.py`: creates 3 works with `audience=None` and 1 with `audience='Adult'`, runs the task, asserts `calculate_presentation` is called exactly 3 times with the `recalculate_classification` policy.
- All files pass syntax checking and black/isort formatting.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
